### PR TITLE
Headless support for DAP debugger

### DIFF
--- a/src/PharoDAP/CommandLineDapUIManager.class.st
+++ b/src/PharoDAP/CommandLineDapUIManager.class.st
@@ -1,0 +1,57 @@
+Class {
+	#name : #CommandLineDapUIManager,
+	#superclass : #NonInteractiveUIManager,
+	#category : #'PharoDAP-UIManager'
+}
+
+{ #category : #debug }
+CommandLineDapUIManager >> debugProcess: process context: context label: title fullView: bool notification: notificationString [
+	
+	(OupsDebugRequest newForContext: context)
+		process: process;
+		label: title;
+		submit
+]
+
+{ #category : #'handle debug requests' }
+CommandLineDapUIManager >> handleDebugRequest: aDebugRequest [
+	| debuggerOpeningStrategy oupsSystem |
+  
+	oupsSystem := OupsDebuggerSystem new.
+	aDebugRequest debugSession logStackToFileIfNeeded.
+	oupsSystem performPreDebugActionsIn: aDebugRequest.
+	oupsSystem ensureExceptionIn: aDebugRequest debugSession.
+	debuggerOpeningStrategy := oupsSystem debuggerSelectionStrategy.
+	debuggerOpeningStrategy openDebuggerForSession:aDebugRequest debugSession.
+	oupsSystem suspendDebuggedProcess: aDebugRequest
+]
+
+{ #category : #debug }
+CommandLineDapUIManager >> handleError: anError log: shouldLog [
+
+	self handleDebugRequest: (OupsDebugRequest newForException: anError)
+
+]
+
+{ #category : #'handle debug requests' }
+CommandLineDapUIManager >> handleWarningDebugRequest: aWarningDebugRequest [
+
+	self handleDebugRequest:  aWarningDebugRequest	
+]
+
+{ #category : #'ui requests' }
+CommandLineDapUIManager >> inform: aString [
+	| ws |
+	ws := (FileLocator home / 'dap_inform') ensureCreateFile writeStream.
+	ws nextPutAll: aString.
+	ws flush;close.
+
+]
+
+{ #category : #'default actions' }
+CommandLineDapUIManager >> unhandledErrorDefaultAction: anException [
+
+	anException debug
+
+	
+]

--- a/src/PharoDAP/DAPServer.class.st
+++ b/src/PharoDAP/DAPServer.class.st
@@ -509,12 +509,8 @@ DAPServer >> debugMode: anObject [
 
 { #category : #'debugger support' }
 DAPServer >> debugSession: aDebugSession [
+
 	'DAP debugSession:' record.
-	debugSession := aDebugSession.
-	"easy to debug if we keep the debugger"
-	aDebugSession exception class = Halt ifTrue:[
-		"jumps the halt stack"
-		debugSession stepOver].
 	self
 		sendMessage:
 			(DAPStoppedEvent new


### PR DESCRIPTION
I've been able to run DAP debugger in headless mode. 
CommandLineDAPUIManager should be selected as default UIManager doing CommandLineDAPUIManager new beDefault.
In iPharo (jupyter kernel) I execute it on my CommandLineHandler. I start the iPharo Kernel by a command line parameter, so when I start pharo I check first if it is in headless mode by sending  #isValidForCurrentSystemConfiguration.

CommandLineDapUIManager isValidForCurrentSystemConfiguration ifTrue:[ 
				CommandLineDapUIManager new beDefault.
				 ]. 
I hope It'll help you to run it in headless mode.

---------------
Also need to remove the stepOver on halt (I put that there...) It doesn't work if it makes the stepOver on halt...don't know why exactly... 