### PR TITLE
removed debugSession := aDebugSession. by mistake

### DIFF
--- a/src/PharoDAP/DAPServer.class.st
+++ b/src/PharoDAP/DAPServer.class.st
@@ -511,6 +511,7 @@ DAPServer >> debugMode: anObject [
 DAPServer >> debugSession: aDebugSession [
 
 	'DAP debugSession:' record.
+	debugSession := aDebugSession.
 	self
 		sendMessage:
 			(DAPStoppedEvent new


### PR DESCRIPTION
I removed the asignation of debugSession by mistake and now is not working

on method DAPServer >> debugSession: aDebugSession

	'DAP debugSession:' record.
	debugSession := aDebugSession.
	self
		sendMessage:
			(DAPStoppedEvent new
				seq: self nextSeq;
				description: aDebugSession exception printString;
				threadId: self threads associations anyOne key;
				reason: 'exception';
				yourself)